### PR TITLE
2 layout UI is broken when width of screen gets to wide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,9 +31,9 @@ function App() {
 
     return (
         <>
-            {getCurrenView(appStatus)}
-            {/* absolute button back to menu */}
+            {/* button back to menu, in-document for mobile & absolute for desktop */}
             {appStatus !== status.MENU && <button className="backToMenuButton" onClick={() => setAppStatus(status.MENU)}>Back to menu</button>}
+            {getCurrenView(appStatus)}
         </>
     );
 }

--- a/src/PreApp.css
+++ b/src/PreApp.css
@@ -36,7 +36,7 @@
 
 .gameBoard {
   display: grid;
-  grid-template-columns: repeat(9, 1fr);
+  grid-template-columns: repeat(9, min-content);
   /* das ist mega cool ↑ */
   margin-left: 27.5vw;
   margin-right: 27.5vw;

--- a/src/PreApp.css
+++ b/src/PreApp.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
+  text-align: center;
 }
 
 .diffDiv {
@@ -144,5 +145,5 @@ Sudoku Board Border
     top: 0;
     left: 0;
   }
-  
+
 }

--- a/src/PreApp.css
+++ b/src/PreApp.css
@@ -1,5 +1,7 @@
-.PreApp {
-  text-align: center;
+.PreApp > div {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
 }
 
 .diffDiv {
@@ -34,12 +36,12 @@
   height: 100%
 }
 
+
 .gameBoard {
   display: grid;
   grid-template-columns: repeat(9, min-content);
   /* das ist mega cool ↑ */
-  margin-left: 27.5vw;
-  margin-right: 27.5vw;
+
   user-select: none;
 
 }

--- a/src/PreApp.css
+++ b/src/PreApp.css
@@ -1,4 +1,4 @@
-.PreApp > div {
+.PreApp {
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
@@ -91,10 +91,14 @@
   cursor: pointer;
 }
 
+/**
+ * 
+ */
 .backToMenuButton {
-  position: absolute;
-  top: 0;
-  left: 0;
+  /* 
+    Removed position: absolute from here, bc. on Mobile it obstructs the header.
+    By removing the "position: absolute" we join this button into the main, top-to-bottom flexbox for layouting
+  */
   font-size: 2em;
   color: white;
   background-color: rgba(0, 0, 0, 0.5);
@@ -125,4 +129,20 @@ Sudoku Board Border
 
 .col0 {
   border-left: 5px solid black;
+}
+
+/* 
+ * @bjesuiter
+ * Best Breakpoint for main Game Screen: 530px 
+ * Best Breakpoint for Difficulty Selection Screen: 580px;
+ * => Choosing 580px for now to not obstruct heading in Difficulty Selection
+*/
+@media screen and (min-width: 580px) {
+
+  .backToMenuButton {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+  
 }

--- a/src/components/Difficulty.tsx
+++ b/src/components/Difficulty.tsx
@@ -17,7 +17,7 @@ const Difficulty = () => {
     }
 
     return (
-        <div>
+        <>
             <h1>Difficulty</h1>
 
             <h3>Select Difficulty for the new Game:</h3>
@@ -29,7 +29,7 @@ const Difficulty = () => {
                 <button className="diffBtn" onClick={() => { changeDifficulty(diffEnum.EXPERT) }}>Expert</button>
                 <button className="diffBtn" onClick={() => { changeDifficulty(diffEnum.RANDOM) }}>Random</button>
             </div>
-        </div>
+        </>
     );
 }
 

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -57,11 +57,11 @@ const Game = () => {
 
 
     return (
-        <div>
+        <>
             <h1>Game</h1>
             <p>Difficulty: {game?.difficulty}</p>
             {game && <GameBoardWrapper game={game} />}
-        </div>
+        </>
     );
 }
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -18,7 +18,7 @@ const Menu = () => {
     let gameRunning = window.localStorage.getItem("gameRunning");
 
     return (
-        <div>
+        <>
             <h1>Menu</h1>
             {gameRunning && <button onClick={() => {
                 setDifficulty(diffEnum.CONTINUE)
@@ -26,7 +26,7 @@ const Menu = () => {
             }
             }>Continue Game</button>}
             <button onClick={() => { changeStatus(status.DIFFICULTY) }} >Start Sudoku Game</button>
-        </div>
+        </>
     );
 }
 


### PR DESCRIPTION
## Changes 

- fix the broken layout by coupling the width of the grid columns to the minimal width of the divs inside it's cells 
- also fixes <https://github.com/Bloodiko/sudoku/issues/5>, 
  by simply having it sit in the main flexbox anyways  
  and elevating it to position:absolute when there's enough screen space (min-width: 580px)